### PR TITLE
docs(README): fix link to object helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ What kind of helpers?
 * [DOM helpers](http://kitze-js-helpers.surge.sh/module-DOM%2520helpers.html)
 * [Mobile helpers](http://kitze-js-helpers.surge.sh/module-Mobile%2520helpers.html)
 * [Number helpers](http://kitze-js-helpers.surge.sh/module-Number%2520helpers.html)
-* [Object helpers](http://kitze-js-helpers.surge.sh/module-Object%252520helpers.html)
+* [Object helpers](http://kitze-js-helpers.surge.sh/module-Object%2520helpers.html)
 * [String helpers](http://kitze-js-helpers.surge.sh/module-String%2520helpers.html)
 * [Type helpers](http://kitze-js-helpers.surge.sh/module-Type%2520helpers.html)
 * [Webpack helpers](http://kitze-js-helpers.surge.sh/module-Webpack%2520helpers.html)


### PR DESCRIPTION
It was 404 before