### PR TITLE
chore: add npm supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=3


### PR DESCRIPTION
Adds repo-level package manager guardrails after the TanStack npm supply-chain incident:

- npm: disable install scripts and add a 3-day release-age gate
- pnpm: block exotic transitive deps, require explicit build-script trust, add release-age/trust-policy guards
- bun/yarn: add release-age gates when their lockfiles are present
- Dependabot: add npm cooldown when no config exists yet

These are intentionally behavior-changing install defaults, so this is opened as a PR instead of pushed straight to the default branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management system to regularly check for package updates on a weekly schedule with appropriate staging intervals for different update severity levels
  * Updated npm configuration to optimize package installation handling and improve project dependency management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitze/kitze-js-helpers/pull/177)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->